### PR TITLE
💝 feat: qdrant implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+# qdrant
+qdrant_storage

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "embedbase"]
-	path = monorepo
-	url = https://github.com/different-ai/embedbase

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,12 @@
 {
-    "python.formatting.provider": "none",
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
-    }
+    },
+    "python.envFile": "${workspaceFolder}/.venv",
+    "python.formatting.provider": "black",
+    "python.testing.pytestArgs": [
+        "test_hard.py",
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
 }

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+
+#* Testing
+
+test: ## [Local development] Run all Python tests with pytest.
+	docker-compose up -d
+	while ! curl -s localhost:6333 > /dev/null; do sleep 1; done
+	poetry run pytest test_hard.py; docker-compose down
+	@echo "Done testing"
+
 #* Installation
 .PHONY: install
 install:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,3 @@
 Embedbase + Qdrant - Advanced and high-performant vector similarity search technology in your AI applications
 
 WIP.
-
-
-pip install git+https://github.com/different-ai/embedbase.git@main#subdirectory=tests
-
-git submodule add https://github.com/different-ai/embedbase embedbase
-
-git submodule update --remote embedbase

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,0 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent / "monorepo"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  qdrant:
+    container_name: qdrant
+    image: qdrant/qdrant
+    restart: always
+    expose:
+      - "6333"
+    ports:
+      - "6333:6333"
+    volumes:
+      - ./qdrant_storage:/qdrant/storage

--- a/poetry.lock
+++ b/poetry.lock
@@ -543,19 +543,18 @@ pipenv = ["pipenv"]
 
 [[package]]
 name = "embedbase"
-version = "1.0.9"
+version = "1.1.3"
 description = "API, SDK & dashboard to easily create, store, and retrieve machine learning embeddings."
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "embedbase-1.0.9-py3-none-any.whl", hash = "sha256:5c13b89a51932060a6de396340bb25b8240afc38d25b4824f35c8ecbc41bdb15"},
-    {file = "embedbase-1.0.9.tar.gz", hash = "sha256:6046b717c5fb51ad2a659290035d2c3fa962b19929ef00ce35819c249863d271"},
+    {file = "embedbase-1.1.3-py3-none-any.whl", hash = "sha256:12eda4a3fff579a9821784a1e12be389917395364d2e8e8dbfb7d019d5d372b3"},
+    {file = "embedbase-1.1.3.tar.gz", hash = "sha256:0b1afea6980b66fe78f3f6c8cbe781c0692e2f3d85a1340129317220a5726640"},
 ]
 
 [package.dependencies]
 fastapi = ">=0.95.1,<0.96.0"
-gunicorn = ">=20.1.0,<21.0.0"
 openai = ">=0.27.0,<0.28.0"
 pandas = ">=1.3.4,<2.0.0"
 pydantic_yaml = {version = ">=0.4.0,<0.5.0", extras = ["pyyaml"]}
@@ -847,27 +846,6 @@ files = [
 grpcio = ">=1.54.0"
 protobuf = ">=4.21.6,<5.0dev"
 setuptools = "*"
-
-[[package]]
-name = "gunicorn"
-version = "20.1.0"
-description = "WSGI HTTP Server for UNIX"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
-    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
-]
-
-[package.dependencies]
-setuptools = ">=3.0"
-
-[package.extras]
-eventlet = ["eventlet (>=0.24.1)"]
-gevent = ["gevent (>=1.4.0)"]
-setproctitle = ["setproctitle"]
-tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "h11"
@@ -1897,72 +1875,100 @@ urllib3 = ">=1.26.14,<2.0.0"
 
 [[package]]
 name = "regex"
-version = "2023.3.23"
+version = "2023.5.4"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 files = [
-    {file = "regex-2023.3.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:845a5e2d84389c4ddada1a9b95c055320070f18bb76512608374aca00d22eca8"},
-    {file = "regex-2023.3.23-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:87d9951f5a538dd1d016bdc0dcae59241d15fa94860964833a54d18197fcd134"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37ae17d3be44c0b3f782c28ae9edd8b47c1f1776d4cabe87edc0b98e1f12b021"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b8eb1e3bca6b48dc721818a60ae83b8264d4089a4a41d62be6d05316ec38e15"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df45fac182ebc3c494460c644e853515cc24f5ad9da05f8ffb91da891bfee879"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7006105b10b59971d3b248ad75acc3651c7e4cf54d81694df5a5130a3c3f7ea"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93f3f1aa608380fe294aa4cb82e2afda07a7598e828d0341e124b8fd9327c715"},
-    {file = "regex-2023.3.23-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787954f541ab95d8195d97b0b8cf1dc304424adb1e07365967e656b92b38a699"},
-    {file = "regex-2023.3.23-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:20abe0bdf03630fe92ccafc45a599bca8b3501f48d1de4f7d121153350a2f77d"},
-    {file = "regex-2023.3.23-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11d00c31aeab9a6e0503bc77e73ed9f4527b3984279d997eb145d7c7be6268fd"},
-    {file = "regex-2023.3.23-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:d5bbe0e1511b844794a3be43d6c145001626ba9a6c1db8f84bdc724e91131d9d"},
-    {file = "regex-2023.3.23-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:ea3c0cb56eadbf4ab2277e7a095676370b3e46dbfc74d5c383bd87b0d6317910"},
-    {file = "regex-2023.3.23-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d895b4c863059a4934d3e874b90998df774644a41b349ebb330f85f11b4ef2c0"},
-    {file = "regex-2023.3.23-cp310-cp310-win32.whl", hash = "sha256:9d764514d19b4edcc75fd8cb1423448ef393e8b6cbd94f38cab983ab1b75855d"},
-    {file = "regex-2023.3.23-cp310-cp310-win_amd64.whl", hash = "sha256:11d1f2b7a0696dc0310de0efb51b1f4d813ad4401fe368e83c0c62f344429f98"},
-    {file = "regex-2023.3.23-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8a9c63cde0eaa345795c0fdeb19dc62d22e378c50b0bc67bf4667cd5b482d98b"},
-    {file = "regex-2023.3.23-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dd7200b4c27b68cf9c9646da01647141c6db09f48cc5b51bc588deaf8e98a797"},
-    {file = "regex-2023.3.23-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22720024b90a6ba673a725dcc62e10fb1111b889305d7c6b887ac7466b74bedb"},
-    {file = "regex-2023.3.23-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b190a339090e6af25f4a5fd9e77591f6d911cc7b96ecbb2114890b061be0ac1"},
-    {file = "regex-2023.3.23-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e76b6fc0d8e9efa39100369a9b3379ce35e20f6c75365653cf58d282ad290f6f"},
-    {file = "regex-2023.3.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7868b8f218bf69a2a15402fde08b08712213a1f4b85a156d90473a6fb6b12b09"},
-    {file = "regex-2023.3.23-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2472428efc4127374f494e570e36b30bb5e6b37d9a754f7667f7073e43b0abdd"},
-    {file = "regex-2023.3.23-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c37df2a060cb476d94c047b18572ee2b37c31f831df126c0da3cd9227b39253d"},
-    {file = "regex-2023.3.23-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4479f9e2abc03362df4045b1332d4a2b7885b245a30d4f4b051c4083b97d95d8"},
-    {file = "regex-2023.3.23-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:e2396e0678167f2d0c197da942b0b3fb48fee2f0b5915a0feb84d11b6686afe6"},
-    {file = "regex-2023.3.23-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:75f288c60232a5339e0ff2fa05779a5e9c74e9fc085c81e931d4a264501e745b"},
-    {file = "regex-2023.3.23-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c869260aa62cee21c5eb171a466c0572b5e809213612ef8d495268cd2e34f20d"},
-    {file = "regex-2023.3.23-cp311-cp311-win32.whl", hash = "sha256:25f0532fd0c53e96bad84664171969de9673b4131f2297f1db850d3918d58858"},
-    {file = "regex-2023.3.23-cp311-cp311-win_amd64.whl", hash = "sha256:5ccfafd98473e007cebf7da10c1411035b7844f0f204015efd050601906dbb53"},
-    {file = "regex-2023.3.23-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6572ff287176c0fb96568adb292674b421fa762153ed074d94b1d939ed92c253"},
-    {file = "regex-2023.3.23-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a610e0adfcb0fc84ea25f6ea685e39e74cbcd9245a72a9a7aab85ff755a5ed27"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:086afe222d58b88b62847bdbd92079b4699350b4acab892f88a935db5707c790"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79e29fd62fa2f597a6754b247356bda14b866131a22444d67f907d6d341e10f3"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c07ce8e9eee878a48ebeb32ee661b49504b85e164b05bebf25420705709fdd31"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b036f401895e854de9fefe061518e78d506d8a919cc250dc3416bca03f6f9a"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78ac8dd8e18800bb1f97aad0d73f68916592dddf233b99d2b5cabc562088503a"},
-    {file = "regex-2023.3.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:539dd010dc35af935b32f248099e38447bbffc10b59c2b542bceead2bed5c325"},
-    {file = "regex-2023.3.23-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9bf4a5626f2a0ea006bf81e8963f498a57a47d58907eaa58f4b3e13be68759d8"},
-    {file = "regex-2023.3.23-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf86b4328c204c3f315074a61bc1c06f8a75a8e102359f18ce99fbcbbf1951f0"},
-    {file = "regex-2023.3.23-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:2848bf76673c83314068241c8d5b7fa9ad9bed866c979875a0e84039349e8fa7"},
-    {file = "regex-2023.3.23-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:c125a02d22c555e68f7433bac8449992fa1cead525399f14e47c2d98f2f0e467"},
-    {file = "regex-2023.3.23-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cd1671e9d5ac05ce6aa86874dd8dfa048824d1dbe73060851b310c6c1a201a96"},
-    {file = "regex-2023.3.23-cp38-cp38-win32.whl", hash = "sha256:fffe57312a358be6ec6baeb43d253c36e5790e436b7bf5b7a38df360363e88e9"},
-    {file = "regex-2023.3.23-cp38-cp38-win_amd64.whl", hash = "sha256:dbb3f87e15d3dd76996d604af8678316ad2d7d20faa394e92d9394dfd621fd0c"},
-    {file = "regex-2023.3.23-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c88e8c226473b5549fe9616980ea7ca09289246cfbdf469241edf4741a620004"},
-    {file = "regex-2023.3.23-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6560776ec19c83f3645bbc5db64a7a5816c9d8fb7ed7201c5bcd269323d88072"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b1fc2632c01f42e06173d8dd9bb2e74ab9b0afa1d698058c867288d2c7a31f3"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fdf7ad455f1916b8ea5cdbc482d379f6daf93f3867b4232d14699867a5a13af7"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5fc33b27b1d800fc5b78d7f7d0f287e35079ecabe68e83d46930cf45690e1c8c"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c49552dc938e3588f63f8a78c86f3c9c75301e813bca0bef13bdb4b87ccf364"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e152461e9a0aedec7d37fc66ec0fa635eca984777d3d3c3e36f53bf3d3ceb16e"},
-    {file = "regex-2023.3.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:db034255e72d2995cf581b14bb3fc9c00bdbe6822b49fcd4eef79e1d5f232618"},
-    {file = "regex-2023.3.23-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:55ae114da21b7a790b90255ea52d2aa3a0d121a646deb2d3c6a3194e722fc762"},
-    {file = "regex-2023.3.23-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ef3f528fe1cc3d139508fe1b22523745aa77b9d6cb5b0bf277f48788ee0b993f"},
-    {file = "regex-2023.3.23-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:a81c9ec59ca2303acd1ccd7b9ac409f1e478e40e96f8f79b943be476c5fdb8bb"},
-    {file = "regex-2023.3.23-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cde09c4fdd070772aa2596d97e942eb775a478b32459e042e1be71b739d08b77"},
-    {file = "regex-2023.3.23-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3cd9f5dd7b821f141d3a6ca0d5d9359b9221e4f051ca3139320adea9f1679691"},
-    {file = "regex-2023.3.23-cp39-cp39-win32.whl", hash = "sha256:7304863f3a652dab5e68e6fb1725d05ebab36ec0390676d1736e0571ebb713ef"},
-    {file = "regex-2023.3.23-cp39-cp39-win_amd64.whl", hash = "sha256:54c3fa855a3f7438149de3211738dd9b5f0c733f48b54ae05aa7fce83d48d858"},
-    {file = "regex-2023.3.23.tar.gz", hash = "sha256:dc80df325b43ffea5cdea2e3eaa97a44f3dd298262b1c7fe9dbb2a9522b956a7"},
+    {file = "regex-2023.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1fa9651141caaafa0d6048695a4a04bc4bf39c75f250a36b1a05c9588a403a9"},
+    {file = "regex-2023.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbc47670e0424a566084e15af9a253b85f90fa26e60fa07e1b10c90df4c8fd07"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7eb07d60c385aec906b82d48447907a2bbf454d0e9ead62168de111accabaf8"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:376fa2ef6a02a004b6fe4ebaa5ba370e7532ec6915efd12e33aa434517f8bbee"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3965a9ab13f1bf3e4af021c7dbe9678dd9f8dc5cc9097b3d3cbbf3ad00574b5d"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3633a07ffeabc14f3cd531f11794bb603267d86e4109cb811a34aee020622d3f"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9322797fddd51ec0312a8b649d9a3ebfabf4826a204ef8e1cc11801013005323"},
+    {file = "regex-2023.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b48820071a49b68ca8734e8b2bd1f26632512154816b261b614e62cc724d9f8a"},
+    {file = "regex-2023.5.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8418b0ee315555ca9786daab00ec8aaf47dfb2698a5be689676e83e88b949f22"},
+    {file = "regex-2023.5.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:2095acff95df0bf6ec3dee672a03d3d78606b4ca419d53fbd606c559cebedf45"},
+    {file = "regex-2023.5.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:ebf0776fdc7a5e0ac11b6db2d69ac77479411b627a96119ffa4427ba32f3bb66"},
+    {file = "regex-2023.5.4-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:ac402ac165f42f41b3aef9e8a9c6fb204dac31faad65b3b0ae6bff4bc9d0dad2"},
+    {file = "regex-2023.5.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:99780a0880d3dab2bb6f863492d38ab90ffdc9daf4fbefb505524f6f3a1c9dbe"},
+    {file = "regex-2023.5.4-cp310-cp310-win32.whl", hash = "sha256:c455d886838dd5a248e7f06e5573275fc854febd206eb937cf632082a06a939f"},
+    {file = "regex-2023.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:e87450db3c444f41e3ac6a09b7a10ddfe54fa1e98bf60ee299fe6d11097540cd"},
+    {file = "regex-2023.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1ef51012493837263236781ac9598f059dc4e5a4d72627bd3ac85cbd5d1b0ee1"},
+    {file = "regex-2023.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5fda1fc36dd923aee070d7aab3a85b448c8b62930900c615bb67db829281103b"},
+    {file = "regex-2023.5.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d28933aa1242814ed737b569b2baf96e4d236c52be454b5dc17afd36bf893c12"},
+    {file = "regex-2023.5.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d8cc797f87c07372e7d300198e1423c2b7bd35b68f375cc6700e26158940c9a"},
+    {file = "regex-2023.5.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63a92f28a3f285dae06aae83227cb66cc87256db040aaf26c1c48ae5221eccde"},
+    {file = "regex-2023.5.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c2ae89c92a04b057b412f88a3359e77600ce966a740e2da212667ce795e1bdc"},
+    {file = "regex-2023.5.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d5a0edefdf800aeef6cf559af75e614fb2eb2d0388f0b132af805fdefcf8ec6"},
+    {file = "regex-2023.5.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fbc5b23b569d96b8c831574c93098b68c6d7ff2509f31268c968152ca4f2ecd0"},
+    {file = "regex-2023.5.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:db5d5c9c7bbcf9cbc541f8adba8c92a7a7abd0de4f0343da4e96fb78ffe9d1a1"},
+    {file = "regex-2023.5.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:ccd0c918971f79bd9a883f13f91343dd2eaefbafd4344aadfe5134a65fb821c3"},
+    {file = "regex-2023.5.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:861ed1249302664f96b2e968216486a02af0a143e0f3cc6fd92b78f11aa18579"},
+    {file = "regex-2023.5.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f576b8dec95456ba0157943a57f5f88c076cf96cc363ef1bf5027c2976fd487a"},
+    {file = "regex-2023.5.4-cp311-cp311-win32.whl", hash = "sha256:21b653c1538cbbc1c58f6d6f3ccb4a5ce56491f0ab370ec057c1c64a152eb48c"},
+    {file = "regex-2023.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:336fb3f585e239362d4f26dd6f904b15d91febfc980f47ed706858f5cee20ce6"},
+    {file = "regex-2023.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6ccd0d7557c4e76303a6429ec9de55cd87334809cda66c0f101831e2ce9073c1"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3e20cf2575b1330687d3dd6242f82278b3bdc09a9f36cc7ac4d45b7dd63c1f5"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaff21326bc5d9be0c2f400931d39274105bd5d06650f0b0215392d1b050d404"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ad84e1d4be3504e7dcd6370b3e847eaf05d5d35cb0818d0bd2d1a26b58c0abd2"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:770f825c7751ce43aae2088fee94f2e60f95e181223642a0bb35cbaeea92001c"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70bd0c121b3c4e641e5c4e633c4581059acad774a1a62bcb15fea3470c2a61cc"},
+    {file = "regex-2023.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:460672c6ec94997755bd37b00302853b9d85a5a433121c198359958e8c10ced5"},
+    {file = "regex-2023.5.4-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:953ba37dd83c424c2cf699c64a8477645fc7c7403ffd2eb1417189eddbbfb4a7"},
+    {file = "regex-2023.5.4-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:77b3333a6cd1161b81bcf018a9bdb3cc567074a913aa69b98b9c8c79be28565c"},
+    {file = "regex-2023.5.4-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:c1155571edd498b6274f969517db6781500fbb24fc91ff740ea5a37c4735b3ba"},
+    {file = "regex-2023.5.4-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:1d98e4748a60c9902ad504e862756c43cc707404fc3025f82ef5bbe50bee3b9e"},
+    {file = "regex-2023.5.4-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:12be293d718e05f7304f715980b1a25b16e34a1ff2121740592559d066f91e67"},
+    {file = "regex-2023.5.4-cp36-cp36m-win32.whl", hash = "sha256:8d5bc5035989852a4ae7dacf8dc99db7c4f21c852486777a98b8efe37af4d8d7"},
+    {file = "regex-2023.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:027d4962340dbd84979fd1c40bfd7ca8362030abfbbff25f1327bbf4867f047c"},
+    {file = "regex-2023.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b132e4507c6404faece005329de7b2b97653ddfeeaf84f058fe820791160dcda"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c300461ed8159f61d979971ba51f1acd1e6f9907d86888e9275165e06ea90f06"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a419384c6c80d58532016c3cf6a3aca009bfb7661f33e119ba7f77ec0e28222a"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b365b8fa0d5fd0208db5b0e94582edb796dde07d1f99c5a9c1ff6be172c374ee"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6686256d1d435ed782ff12ef11e074705911a40d3907b986e53ca9a996e88489"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c10b1388106447db0cdb8e340d06fa2d49b822368a049c36928d3c24296c2e37"},
+    {file = "regex-2023.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d321dd059fd00482537aaba919e29189ea4ab6a03528881267982bb7707f610"},
+    {file = "regex-2023.5.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:5f82d4e0725788787216c9ae53116e6e477b2d97f29ec1e5086f5afbab5716b0"},
+    {file = "regex-2023.5.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:24db1c0fc20850db47977824a99fdae81d6764adaf8192dd874185d9e7166dbb"},
+    {file = "regex-2023.5.4-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:89f54d4bbd452a5ee01dc31ec918f7b1f32483f13d3598af1acf5ea82ad82ad3"},
+    {file = "regex-2023.5.4-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:797bab57e1317c940030f3c15d48c01e1f16d12ba0f6a807ee0bebdc1cfe3f2d"},
+    {file = "regex-2023.5.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:1ad00c9aae6090d052c0ee16a2737a7154031793e6c7b58a629eed8d8aa77e31"},
+    {file = "regex-2023.5.4-cp37-cp37m-win32.whl", hash = "sha256:06fe9870165d4975a8a3e27a83919b9014b35dd2ee7061a5f2be8e579294cedc"},
+    {file = "regex-2023.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:6469c2baf450fd1e648752b113a1fc1d67dfbad359f6171be954bacf7b09d126"},
+    {file = "regex-2023.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5cc67b3562aada6682ae45f2ea40819baa6bffe38155883100f8779c22c8c087"},
+    {file = "regex-2023.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5a98814d42282153c30d674ee34ea114a03ea8d32fd5d9b924d46fbeb2c7eb15"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c704e7062c59d2f7e2eebda2c0c0b69bd807ca6579c3a21fc4b1d8505cfc090"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f2bc7249840faacfff6196e5b5ffeb3fdaf078986521a1cda34e9be5607e773b"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d0ac14c36d91b191d1cb073fb5ac49937d88a5c8b051ced3875321a525202c34"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea2d66c1fd898d81b8ce0f95afab9ba0ab522cf08810f11fa28ad958706cd2b2"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0130a2fdd6f033c3e3710d0b950cc6abd3133c5af88c40c78e77641cb6f6cf8a"},
+    {file = "regex-2023.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ff8fef88029d0420315935041db517855ea022889fa8d54959943e39fffebf59"},
+    {file = "regex-2023.5.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2762750332f57820c0f38ade87ce4ebe671b178892faed0112f574f0b42801cf"},
+    {file = "regex-2023.5.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:dbcb49036a6a6065035ac2acc1ad6a918f9e09ef2d0f9392dc90b8756f789f95"},
+    {file = "regex-2023.5.4-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:c40f7e8c02b287550166a3e36dbb89f9387db86a71101f6242668e3ef979cd2a"},
+    {file = "regex-2023.5.4-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:1dc5e9a847613679ac8bd0386a0e54f2958441a0fcc123778637e433041aa763"},
+    {file = "regex-2023.5.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa92f9ad481108a7e4c5a5234608f7c718f8b67003ce4719a4d2735d82b54167"},
+    {file = "regex-2023.5.4-cp38-cp38-win32.whl", hash = "sha256:00f6f26e748c797a041ab6957f4cacc66a7fbd5dc5f627760985f5c5b7de2af6"},
+    {file = "regex-2023.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:6f02105d4a511f550dcd63f750937d1607a1f6dc253c798c4adf36aba89215a3"},
+    {file = "regex-2023.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:49a77f0b62a4122cf578d1194658973c435e6d2a9611013be11b6750056a5930"},
+    {file = "regex-2023.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a664857dd9b1076942c4d73c54a031066ee0ae88a438e7a1e0e79c1c5ddf47a"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b887d87188489859411d0c7e741f7dfe8a3ca5946b0db8b3c9e5daecc089b62"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:037f4be6a240a11a6d3397e932ef5d3ec5855858910792a0ab7d351bd0333533"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bda905e040e6c2875a7dde9652a9e0c426aaac6058568cc064f8128b061439ee"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91f47522688955cb33190f8354ccaa1cc058d05e73f99afe9ace40db36c159e8"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a7ab3440f0c653dee8b42af858da6e07615c64ba86a6b3509a0ecf44eabdb11"},
+    {file = "regex-2023.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04a825fd9f5931263eccd0cbdbf171a9792fa1bf2642ca62800b57689ca1b660"},
+    {file = "regex-2023.5.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0eee66c4ce6ced2e9d5d4497a569bab6257a6d118eb43dd57cceb61ba00b62d8"},
+    {file = "regex-2023.5.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e708e69c4d3bc41df29efb94aadc5578c841b2cd02f8cbb1bcfbf280f2801238"},
+    {file = "regex-2023.5.4-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:b87d38717ed855583ae1693f6095fc9c06b7dde4ddec782b41aa92931dd60e7c"},
+    {file = "regex-2023.5.4-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:50e00ab84396bfbeb1bede61eff6641f957b6532e74e02be480d71914e20e2ac"},
+    {file = "regex-2023.5.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0c731522eaf74166066fcf91fe7fe3c3617cc5e8df0c150132282d0dd5225afc"},
+    {file = "regex-2023.5.4-cp39-cp39-win32.whl", hash = "sha256:97fd2885df308edcdf96baa632192a4291f3ed5b072c0bc3f29dc1e6de40ffa4"},
+    {file = "regex-2023.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:cb22580ce5e2eee138a78df40444151ff51c91acd11be546216a046677c75593"},
+    {file = "regex-2023.5.4.tar.gz", hash = "sha256:9e1b4b0b4baff934ef3c0ac56578a6b773f7f90ad1db3ff843ee40d83bdae09f"},
 ]
 
 [[package]]
@@ -1986,6 +1992,26 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-mock"
+version = "1.10.0"
+description = "Mock out responses from the requests package"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "requests-mock-1.10.0.tar.gz", hash = "sha256:59c9c32419a9fb1ae83ec242d98e889c45bd7d7a65d48375cc243ec08441658b"},
+    {file = "requests_mock-1.10.0-py2.py3-none-any.whl", hash = "sha256:2fdbb637ad17ee15c06f33d31169e71bf9fe2bdb7bc9da26185be0dd8d842699"},
+]
+
+[package.dependencies]
+requests = ">=2.3,<3"
+six = "*"
+
+[package.extras]
+fixture = ["fixtures"]
+test = ["fixtures", "mock", "purl", "pytest", "requests-futures", "sphinx", "testrepository (>=0.0.18)", "testtools"]
 
 [[package]]
 name = "rich"
@@ -2672,4 +2698,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "07e0a4597a5c82a20d84daf944503202ae8d0ec2a021bda6aa7d79b0e7e531eb"
+content-hash = "d875fca728fb35c215c88703dd68f6279cae481afdd6bbbfc8a139ac7bee9dd0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-embedbase = "^1.0.9"
+embedbase = "^1.1.3"
 qdrant-client = "^1.1.6"
 
 
@@ -53,6 +53,7 @@ pytest-html = "^3.1.1"
 pytest-cov = "^4.0.0"
 httpx = "^0.24.0"
 pytest-asyncio = "^0.21.0"
+requests_mock = "^1.9.3"
 
 [tool.black]
 target-version = ["py38"]

--- a/qdrant_db.py
+++ b/qdrant_db.py
@@ -1,25 +1,72 @@
+import asyncio
 from embedbase.database import VectorDatabase
-from abc import ABC, abstractmethod
 from typing import Coroutine, List, Optional
 from pandas import DataFrame
+from embedbase.utils import BatchGenerator
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import PointStruct
+from qdrant_client.http.models import (
+    Filter,
+    FieldCondition,
+    MatchValue,
+    PointIdsList,
+    FilterSelector,
+    VectorParams,
+    Distance,
+    HasIdCondition,
+)
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+from embedbase.database.base import SearchResponse, SelectResponse, Dataset
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
 
 
 class Qdrant(VectorDatabase):
-    def __init__(
-        self,
-    ):
-        """
-        Qdrant is powering the next generation of AI applications with advanced
-        and high-performant vector similarity search technology.
+    """
+    Qdrant is powering the next generation of AI applications with advanced
+    and high-performant vector similarity search technology.
 
-        Qdrant is a vector database & vector similarity search engine.
-        It deploys as an API service providing search for the nearest high-dimensional vectors.
-        With Qdrant, embeddings or neural network encoders can be turned into
-        full-fledged applications for matching, searching, recommending, and much more!
+    Qdrant is a vector database & vector similarity search engine.
+    It deploys as an API service providing search for the nearest high-dimensional vectors.
+    With Qdrant, embeddings or neural network encoders can be turned into
+    full-fledged applications for matching, searching, recommending, and much more!
+    """
+
+    client: QdrantClient
+
+    def _try_or_create_collection(
+        self, dataset_id: str, func: Callable[[], T], kwargs
+    ) -> T:
         """
-        raise NotImplementedError(
-            "Qdrant is not yet implemented. Please use another database."
-        )
+        Try to run the Qdrant function and if it fails, create the collection and try again.
+        :param dataset_id: dataset id
+        :param func: function to run
+        """
+        try:
+            return func(**kwargs)
+        except UnexpectedResponse as exc:
+            if exc.status_code != 404:
+                raise exc
+            self.client.create_collection(
+                collection_name=dataset_id,
+                vectors_config=VectorParams(
+                    size=self._dimensions, distance=Distance.COSINE
+                ),
+            )
+            return func(**kwargs)
+
+    def __init__(self, host: str = "localhost", port: int = 6333, **kwargs):
+        """
+
+        :param host: qdrant host
+        :param port: qdrant port
+        """
+
+        super().__init__(**kwargs)
+
+        self.client = QdrantClient(host=host, port=port)
 
     async def select(
         self,
@@ -28,7 +75,7 @@ class Qdrant(VectorDatabase):
         dataset_id: Optional[str] = None,
         user_id: Optional[str] = None,
         distinct: bool = True,
-    ) -> List[dict]:
+    ):
         """
         :param ids: list of ids
         :param hashes: list of hashes
@@ -37,7 +84,51 @@ class Qdrant(VectorDatabase):
         :param distinct: distinct
         :return: list of documents
         """
-        raise NotImplementedError
+        # either ids or hashes must be provided
+        assert ids or hashes, "ids or hashes must be provided"
+
+        must = []
+        should = []
+        if user_id:
+            must.append(
+                FieldCondition(key="user_id", range=MatchValue(value="user_id"))
+            )
+        if hashes:
+            for h in hashes:
+                should.append(FieldCondition(key="hash", match=MatchValue(value=h)))
+        if ids:
+            should.append(HasIdCondition(has_id=ids))
+
+        try:
+            search_result = self.client.scroll(
+                collection_name=dataset_id,
+                # query_vector=[0.0] * self._dimensions,
+                query_filter=Filter(
+                    should=should,
+                    must=must,
+                ),
+                with_payload=True,
+                with_vectors=True,
+                # TODO pagination
+                limit=10_000,
+            )
+        except UnexpectedResponse as exc:
+            # ignore unexisting collections
+            if exc.status_code != 404:
+                raise exc
+            return []
+        responses = []
+        for e in search_result[0]:
+            responses.append(
+                SelectResponse(
+                    id=e.id,
+                    data=e.payload.get("data"),
+                    metadata=e.payload.get("metadata"),
+                    hash=e.payload.get("hash"),
+                    embedding=e.vector,
+                )
+            )
+        return responses
 
     async def update(
         self,
@@ -45,26 +136,64 @@ class Qdrant(VectorDatabase):
         dataset_id: str,
         user_id: Optional[str] = None,
         batch_size: Optional[int] = 100,
+        # todo: implement store_data someday
         store_data: bool = True,
-    ) -> Coroutine:
-        """
-        :param df: dataframe
-        :param dataset_id: dataset id
-        :param user_id: user id
-        :param batch_size: batch size
-        :param store_data: store data in database?
-        """
-        raise NotImplementedError
+    ):
+        df_batcher = BatchGenerator(batch_size)
+        batches = [batch_df for batch_df in df_batcher(df)]
+
+        async def _insert(batch_df: DataFrame):
+            points = [
+                PointStruct(
+                    id=row.id,
+                    vector=row.embedding,
+                    payload={
+                        "dataset_id": dataset_id,
+                        "user_id": user_id,
+                        "metadata": row.metadata,
+                        "data": row.data,
+                        "hash": row.hash,
+                    },
+                )
+                for _, row in batch_df.iterrows()
+            ]
+
+            response = self._try_or_create_collection(
+                dataset_id=dataset_id,
+                func=self.client.upsert,
+                kwargs={"collection_name": dataset_id, "points": points},
+            )
+            return response
+
+        await asyncio.gather(*[_insert(batch_df) for batch_df in batches])
 
     async def delete(
-        self, ids: List[str], dataset_id: str, user_id: Optional[str] = None
-    ) -> None:
-        """
-        :param ids: list of ids
-        :param dataset_id: dataset id
-        :param user_id: user id
-        """
-        raise NotImplementedError
+        self,
+        ids: List[str],
+        dataset_id: str,
+        user_id: Optional[str] = None,
+    ):
+        must = [
+            HasIdCondition(has_id=ids),
+        ]
+        if user_id:
+            must.append(
+                FieldCondition(key="user_id", range=MatchValue(value="user_id"))
+            )
+        try:
+            self.client.delete(
+                wait=True,
+                collection_name=dataset_id,
+                points_selector=FilterSelector(
+                    filter=Filter(
+                        must=must,
+                    )
+                ),
+            )
+        except UnexpectedResponse as exc:
+            # ignore unexisting collections
+            if exc.status_code != 404:
+                raise exc
 
     async def search(
         self,
@@ -72,26 +201,88 @@ class Qdrant(VectorDatabase):
         top_k: Optional[int],
         dataset_ids: List[str],
         user_id: Optional[str] = None,
-    ) -> List[dict]:
+    ):
+        must = []
+        if user_id:
+            must.append(
+                FieldCondition(key="user_id", range=MatchValue(value="user_id"))
+            )
+        try:
+            search_result = self.client.search(
+                # TODO: does not support cross-collection search atm
+                collection_name=dataset_ids[0],
+                query_vector=vector,
+                limit=top_k,
+                query_filter=Filter(
+                    must=must,
+                ),
+                with_vectors=True,
+                with_payload=True,
+            )
+        except UnexpectedResponse as exc:
+            # ignore unexisting collections
+            if exc.status_code != 404:
+                raise exc
+            return []
+        search_response = []
+        for e in search_result:
+            search_response.append(
+                SearchResponse(
+                    id=e.id,
+                    score=e.score,
+                    data=e.payload.get("data"),
+                    metadata=e.payload.get("metadata"),
+                    hash=e.payload.get("hash"),
+                    embedding=e.vector,
+                )
+            )
+        return search_response
+
+    async def clear(self, dataset_id: str, user_id: Optional[str] = None):
         """
-        :param vector: vector
-        :param top_k: top k
         :param dataset_id: dataset id
         :param user_id: user id
-        :return: list of documents
         """
-        raise NotImplementedError
+        must = []
+        if user_id:
+            must.append(
+                FieldCondition(key="user_id", range=MatchValue(value="user_id"))
+            )
+        try:
+            self.client.delete(
+                wait=True,
+                collection_name=dataset_id,
+                points_selector=FilterSelector(filter=Filter(must=must)),
+            )
+        except UnexpectedResponse as exc:
+            # ignore unexisting collection
+            if exc.status_code != 404:
+                raise
 
-    async def clear(self, dataset_id: str, user_id: Optional[str] = None) -> None:
-        """
-        :param dataset_id: dataset id
-        :param user_id: user id
-        """
-        raise NotImplementedError
-
-    async def get_datasets(self, user_id: Optional[str] = None) -> List[dict]:
+    async def get_datasets(self, user_id: Optional[str] = None):
         """
         :param user_id: user id
         :return: list of datasets
         """
-        raise NotImplementedError
+        must = []
+        if user_id:
+            must.append(
+                FieldCondition(key="user_id", range=MatchValue(value="user_id"))
+            )
+        result = self.client.get_collections()
+        response = []
+        # todo: parallelize
+        for e in result.collections:
+            count = self.client.count(
+                collection_name=e.name,
+                count_filter=Filter(
+                    must=must,
+                ),
+            )
+            response.append(
+                Dataset(
+                    dataset_id=e.name,
+                    documents_count=count,
+                )
+            )
+        return response

--- a/test_hard.py
+++ b/test_hard.py
@@ -1,0 +1,244 @@
+"""
+Tests at the database abstraction level.
+"""
+
+import hashlib
+from typing import List
+
+import numpy as np
+import pandas as pd
+import pytest
+import uuid
+from embedbase.database.base import VectorDatabase
+from qdrant_db import Qdrant
+unit_testing_dataset = "unit_test"
+vector_databases: List[VectorDatabase] = [Qdrant(host="localhost", port=6333)]
+
+@pytest.mark.asyncio
+async def test_search():
+    d = [
+        "Bob is a human",
+        "The quick brown fox jumps over the lazy dog",
+    ]
+    embeddings = [
+        # random embedding of length 1536
+        np.random.rand(1536).tolist(),
+        np.random.rand(1536).tolist(),
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "data": d[i],
+                "embedding": embedding,
+                "id": str(uuid.uuid4()),
+                "metadata": {"test": "test"},
+            }
+            for i, embedding in enumerate(embeddings)
+        ],
+        columns=["data", "embedding", "id", "hash", "metadata"],
+    )
+    df.hash = df.data.apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+
+    for vector_database in vector_databases:
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(df, unit_testing_dataset)
+        results = await vector_database.search(
+            embeddings[0],
+            top_k=2,
+            dataset_ids=[unit_testing_dataset],
+        )
+        assert len(results) > 0, f"failed for {vector_database}"
+        assert results[0].id == df.id[0], f"failed for {vector_database}"
+        assert results[0].data == d[0], f"failed for {vector_database}"
+        assert len(results[0].embedding) > 0, f"failed for {vector_database}"
+        assert results[0].score > 0, f"failed for {vector_database}"
+
+
+@pytest.mark.asyncio
+async def test_fetch():
+    d = [
+        "Bob is a human",
+        "The quick brown fox jumps over the lazy dog",
+    ]
+    embeddings = [
+        [0.0] * 1536,
+        [0.0] * 1536,
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "data": d[i],
+                "embedding": embedding,
+                "id": str(uuid.uuid4()),
+                "metadata": {"test": "test"},
+            }
+            for i, embedding in enumerate(embeddings)
+        ],
+        columns=["data", "embedding", "id", "hash", "metadata"],
+    )
+    df.hash = df.data.apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+
+    for vector_database in vector_databases:
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(df, unit_testing_dataset)
+        results = await vector_database.select(
+            ids=[df.id[0]], dataset_id=unit_testing_dataset
+        )
+        assert len(results) > 0, f"failed for {vector_database}"
+        assert results[0].id == df.id[0], f"failed for {vector_database}"
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_hash():
+    d = [
+        "Bob is a human",
+        "The quick brown fox jumps over the lazy dog",
+    ]
+    embeddings = [
+        [0.0] * 1536,
+        [0.0] * 1536,
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "data": d[i],
+                "embedding": embedding,
+                "id": str(uuid.uuid4()),
+                "metadata": {"test": "test"},
+            }
+            for i, embedding in enumerate(embeddings)
+        ],
+        columns=["data", "embedding", "id", "hash", "metadata"],
+    )
+    df.hash = df.data.apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+
+    for vector_database in vector_databases:
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(df, unit_testing_dataset)
+        results = await vector_database.select(
+            hashes=[df.hash[0]], dataset_id=unit_testing_dataset
+        )
+        assert len(results) > 0, f"failed for {vector_database}"
+        assert results[0].id == df.id[0], f"failed for {vector_database}"
+
+
+@pytest.mark.asyncio
+async def test_clear():
+    data = [
+        # random numpy array of length 1536
+        np.random.rand(1536).tolist(),
+        np.random.rand(1536).tolist(),
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "data": "Bob is a human",
+                "embedding": embedding,
+                "id": str(uuid.uuid4()),
+                "metadata": {"test": "test"},
+            }
+            for i, embedding in enumerate(data)
+        ],
+        columns=["data", "embedding", "id", "hash", "metadata"],
+    )
+    df.hash = df.data.apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+
+    for vector_database in vector_databases:
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(df, unit_testing_dataset)
+        results = await vector_database.search(
+            data[0],
+            top_k=2,
+            dataset_ids=[unit_testing_dataset],
+        )
+        ids = [result.id for result in results]
+        assert ids[0] == df.id[0], f"failed for {vector_database}"
+        assert ids[1] == df.id[1], f"failed for {vector_database}"
+        # check there is score
+        assert results[0].score >= 0, f"failed for {vector_database}"
+        await vector_database.clear(unit_testing_dataset)
+
+    for vector_database in vector_databases:
+        results = await vector_database.search(
+            data[0],
+            top_k=2,
+            dataset_ids=[unit_testing_dataset],
+        )
+        assert len(results) == 0, f"failed for {vector_database}"
+
+
+@pytest.mark.asyncio
+async def test_upload():
+    data = [
+        # random numpy array of length 1536
+        np.random.rand(1536).tolist(),
+        np.random.rand(1536).tolist(),
+    ]
+    df = pd.DataFrame(
+        [
+            {
+                "data": "Bob is a human",
+                "embedding": embedding,
+                "id": str(uuid.uuid4()),
+                "metadata": {"test": "test"},
+            }
+            for i, embedding in enumerate(data)
+        ],
+        columns=[
+            "data",
+            "embedding",
+            "id",
+            "hash",
+            "metadata",
+        ],
+    )
+    df.hash = df.data.apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+
+    for vector_database in vector_databases:
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(df, unit_testing_dataset)
+
+        results = await vector_database.search(
+            data[0],
+            top_k=2,
+            dataset_ids=[unit_testing_dataset],
+        )
+        ids = [result.id for result in results]
+        assert ids[0] == df.id[0], f"failed for {vector_database}"
+        assert ids[1] == df.id[1], f"failed for {vector_database}"
+
+
+@pytest.mark.asyncio
+async def test_batch_select_large_content():
+    """
+    should not throw an error
+    """
+    d = []
+    for i in range(1000):
+        d.append("a" * i)
+    hashes = [hashlib.sha256(x.encode()).hexdigest() for x in d]
+    for vector_database in vector_databases:
+        # add documents
+        await vector_database.clear(unit_testing_dataset)
+        await vector_database.update(
+            pd.DataFrame(
+                [
+                    {
+                        "data": x,
+                        "embedding": [0.0] * 1536,
+                        "id": str(uuid.uuid4()),
+                        "metadata": {"test": "test"},
+                        "hash": hashes[i],
+                    }
+                    for i, x in enumerate(d)
+                ],
+                columns=["data", "embedding", "id", "hash", "metadata"],
+            ),
+            unit_testing_dataset,
+        )
+        results = await vector_database.select(
+            hashes=list(set(hashes)),
+            dataset_id=unit_testing_dataset,
+            user_id=None,
+        )
+        assert len(list(results)) == len(d), f"failed for {vector_database}"

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,8 +1,0 @@
-from monorepo.tests.test_end_to_end import vector_databases
-from qdrant_db import Qdrant
-
-# override default vector databases with our integration
-vector_databases.clear()
-vector_databases.append(Qdrant())
-
-# poetry run pytest test_integration.py


### PR DESCRIPTION
Implementation of https://qdrant.tech vector database on `embedbase==1.1.3`

What to look at?
- `qdrant_db.py`
- `test_hard.py`

Currently the unit tests are 99% copy paste from embedbase [unit tests](https://github.com/different-ai/embedbase/blob/main/tests/database/test_db.py) (in the future we want to share these tests as a pip package)

Tests are ran against a local `qdrant` container using `make test`